### PR TITLE
Add `<serialNumber>` to Fauxmo's response

### DIFF
--- a/src/fauxmo/protocols.py
+++ b/src/fauxmo/protocols.py
@@ -78,6 +78,7 @@ class Fauxmo(asyncio.Protocol):
             "<manufacturer>Belkin International Inc.</manufacturer>"
             "<modelName>Emulated Socket</modelName>"
             "<modelNumber>3.1415</modelNumber>"
+            f"<serialNumber>{self.serial}</serialNumber>"
             f"<UDN>uuid:Socket-1_0-{self.serial}</UDN>"
             "<serviceList>"
             "<service>"
@@ -390,7 +391,7 @@ class SSDPServer(asyncio.DatagramProtocol):
             port = device.get("port")
 
             location = f"http://{ip_address}:{port}/setup.xml"
-            serial = make_serial(name)
+            serial = make_serial(f"{name}{location}")
             usn = (
                 f"uuid:Socket-1_0-{serial}::"
                 f'{discover_pattern.lstrip("ST: ")}'

--- a/src/fauxmo/utils.py
+++ b/src/fauxmo/utils.py
@@ -42,20 +42,20 @@ def get_local_ip(ip_address: str = None) -> str:
     return ip_address
 
 
-def make_serial(name: str) -> str:
-    """Create a persistent UUID from the device name.
+def make_serial(identifier: str) -> str:
+    """Create a persistent UUID from an input string.
 
-    Returns a suitable UUID derived from `name`. Should remain static for a
-    given name.
+    Returns a suitable UUID derived from `identifier`. Should remain static for
+    a given input.
 
     Args:
-        name: Friendly device name (e.g. "living room light")
+        identifier: input string that will uniquely identify a device
 
     Returns:
         Persistent UUID as string
 
     """
-    return str(uuid.uuid3(uuid.NAMESPACE_X500, name))
+    return str(uuid.uuid3(uuid.NAMESPACE_X500, identifier))
 
 
 def module_from_file(modname: str, path_str: str) -> ModuleType:


### PR DESCRIPTION
[pywemo](https://github.com/pavoni/pywemo/) seems to use this bit of xml
to set a [device attribute called `.serialNumber`][0].

HomeAssistant in turn deduplicates discovered devices based on this
attribute][1].

Without it set in XML, HomeAssistant only discovers the *first* Fauxmo
device, assuming the remainder are duplicates (since they have the same
serial number).

This commit adds the serialNumber to the XML, and also adds the location
(which includes host and port) to the generation of the serial number,
just in case there were two devices with the same name for some reason.
Probably unnecessary, but shouldn't cause harm as far as I can tell.

Fixes https://github.com/n8henrie/fauxmo/issues/88

[0]: https://github.com/pavoni/pywemo/blob/c32a6d0dbf7c0aee4935f778fd683aa59db3f073/pywemo/ouimeaux_device/api/xsd/device.py#L730
[1]: https://github.com/home-assistant/home-assistant/blob/7b86f0f9265dc8cdcf7ed92c0db7340604134569/homeassistant/components/wemo/__init__.py#L166

NB: *please* make an issue prior to embarking on any significant effort towards
a pull request. This will serve as a unified place for discussion and hopefully
make sure that the change seems reasonable to merge once its implementation is
complete.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Status

**READY/IN DEVELOPMENT**

## Related Issues

- [First related issue](https://github.com/n8henrie/fauxmo/issues/1)

## Todos

- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce

E.g.:

```bash
git checkout -b <feature_branch> master
git pull https://github.com/<user>/fauxmo.git <feature_branch>
pytest tests/
```

## Other notes


